### PR TITLE
Add Dexie.js to production-ready options

### DIFF
--- a/src/data/blog/i-went-down-the-linear-rabbit-hole.md
+++ b/src/data/blog/i-went-down-the-linear-rabbit-hole.md
@@ -73,6 +73,7 @@ Fortunately, the local-first community has been building solutions. Here's the c
 - **[Electric SQL](https://electric-sql.com/)** - Postgres-backed sync engine
 - **[PowerSync](https://www.powersync.com/)** - Enterprise-focused solution
 - **[Jazz](https://jazz.tools/)** - The one that caught my eye (see below)
+- **[Dexie Cloud](https://dexie.org/cloud/)** - If already using Dexie.js
 - **[Replicache](https://replicache.dev/)** - The OG (RIP)
 - **[Zero](https://zero.rocicorp.dev/)** - Replicache team's new approach
 - **[Triplit](https://www.triplit.dev/)** - TripleStore-based sync


### PR DESCRIPTION
Hey thanks for a great article! Please consider my PR to add Dexie Cloud to the options. It's a lot similar architecture as Jazz in simplicity and access model and easy for those already familiar with [Dexie.js](https://github.com/dexie/Dexie.js). 

Dexie.js has 13k stars and is already trusted by major players such as ChatGPT, Microsoft ToDo, WhatsApp Web and Facebook Messenger.